### PR TITLE
Treat extent as optional per Mapbox Vector Tile v2 spec

### DIFF
--- a/include/mapbox/vector_tile.hpp
+++ b/include/mapbox/vector_tile.hpp
@@ -373,7 +373,6 @@ inline layer::layer(protozero::data_view const& layer_view) :
     features()
 {
     bool has_name = false;
-    bool has_extent = false;
     bool has_version = false;
     protozero::pbf_reader layer_pbf(layer_view);
     while (layer_pbf.next()) {
@@ -405,7 +404,6 @@ inline layer::layer(protozero::data_view const& layer_view) :
         case LayerType::EXTENT:
             {
                 extent = layer_pbf.get_uint32();
-                has_extent = true;
             }
             break;
         case LayerType::VERSION:
@@ -421,13 +419,10 @@ inline layer::layer(protozero::data_view const& layer_view) :
             break;
         }
     }
-    if (!has_version || !has_name || !has_extent) {
+    if (!has_version || !has_name) {
         std::string msg("missing required field:");
         if (!has_version) {
             msg += " version ";
-        }
-        if (!has_extent) {
-            msg += " extent ";
         }
         if (!has_name) {
             msg += " name";

--- a/test/unit/vector_tile.test.cpp
+++ b/test/unit/vector_tile.test.cpp
@@ -138,3 +138,27 @@ TEST_CASE( "Handle layer with duplicate keys" ) {
     REQUIRE(opt_val.is<std::string>()); \
     REQUIRE(opt_val.get<std::string>() == "lake"); \
 }
+
+TEST_CASE( "Layer without explicit extent field uses Mapbox Vector spec default of 4096" ) {
+    // Minimal valid Mapbox Vector v2 tile with one point feature, deliberately omitting
+    // the optional `extent` field.  The Mapbox Vector v2 spec defines extent as optional
+    // with a default value of 4096; parsing must succeed and return that default.
+    //
+    // Encoded layout (protobuf wire format):
+    //   tile { layer { name:"test" feature { type:POINT geometry:[MoveTo(0,0)] } version:2 } }
+    // Note: no extent field — field 5 is intentionally absent.
+    std::string buffer{
+        '\x1a', '\x11',                                  // tile: layers[0]
+        '\x0a', '\x04', 't', 'e', 's', 't',              //   name = "test"
+        '\x12', '\x07',                                  //   features[0]
+            '\x18', '\x01',                              //     type = POINT
+            '\x22', '\x03', '\x09', '\x00', '\x00',      //     geometry: MoveTo(0,0)
+        '\x78', '\x02'                                   //   version = 2
+    };
+    mapbox::vector_tile::buffer tile(buffer);
+    auto const layer_names = tile.layerNames();
+    REQUIRE(layer_names.size() == 1);
+    auto const layer = tile.getLayer("test");
+    REQUIRE(layer.getExtent() == 4096);
+    REQUIRE(layer.featureCount() == 1);
+}


### PR DESCRIPTION
The Mapbox Vector Tile v2 specification defines the layer extent field as optional with a default value of 4096. The parser already initialised extent to 4096 in the layer constructor, but the post-parse validation check incorrectly required the field to be explicitly present in the encoded data.

Remove extent from the required-field check. Version and name remain required, matching what the spec actually mandates.

Add a test case that parses a tile with no extent field and asserts that `getExtent()` returns 4096.